### PR TITLE
Update frontend on new order

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "concurrently -k -n server,web -c green,blue \"pnpm:server:watch\" \"pnpm:dev:web\"",
     "dev:web": "vite --host",
     "server": "node ./server/index.js",
-    "server:watch": "nodemon --watch server --ext js,json --exec node ./server/index.js",
+    "server:watch": "nodemon --watch server --ext js --exec node ./server/index.js",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
Update `nodemon` configuration to prevent server restarts on `pedidos.json` changes, maintaining stable SSE connections.

The server was restarting because `nodemon` was configured to watch `.json` files in the `server/` directory. Each new order, written to `server/pedidos.json`, triggered a server restart, breaking the frontend's EventSource connection. By excluding `.json` from `nodemon`'s watch list, only the frontend updates via SSE without server interruption.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e4747e9-969a-40d9-92a0-8db116549fdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e4747e9-969a-40d9-92a0-8db116549fdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

